### PR TITLE
add autoload cookie

### DIFF
--- a/ac-helm.el
+++ b/ac-helm.el
@@ -98,6 +98,7 @@
 (require 'auto-complete)
 (require 'popup)
 
+;;;###autoload
 (defun ac-complete-with-helm ()
   "Select `auto-complete' candidates by `helm'.
 It is useful to narrow candidates."


### PR DESCRIPTION
ドキュメントでは ELPAからインストールした場合 `require`不要となっていますが、
autoload cookieが適切に設定されていない無理だと思います。

ELPA等では autoload関連の関数を使って autoload cookieがついた関数, S式に
ついて autoloadの設定を自動生成します。autoloadとはある関数を実行するとき
それが定義されるファイルをロードするという設定です。これにより、
遅延ロードが実現できます。package.elではその自動生成されたファイルを
`package-initialize`で読み込んでいるので、`require`が不要となります。
(きちんと autoload cookieが設定されている場合)

今回の修正で `ac-complete-with-helm`関数が実行されるとき、`ac-helm.el`を
ロードするという設定が自動生成されます。具体的には以下のような感じです。
(`M-x update-file-autoloads`で生成. もともとのコードだと autoloadの設定がない
ので何も生成されない)

``` elisp
;;; test.el --- automatically extracted autoloads
;;
;;; Code:


;;;### (autoloads (ac-complete-with-helm) "ac-helm" "ac-helm.el"
;;;;;;  (20838 51704))
;;; Generated autoloads from ac-helm.el

(autoload 'ac-complete-with-helm "ac-helm" "\
Select `auto-complete' candidates by `helm'.
It is useful to narrow candidates.

\(fn)" t nil)

;;;***

(provide 'test)
;; Local Variables:
;; version-control: never
;; no-byte-compile: t
;; no-update-autoloads: t
;; coding: utf-8
;; End:
;;; test.el ends here
```

よろしくお願いします。
