### PR TITLE
helm-match-plugin.el is renamed to helm-multi-match.el

### DIFF
--- a/ac-helm.el
+++ b/ac-helm.el
@@ -56,7 +56,7 @@
 ;;; Code:
 
 (require 'helm)
-(require 'helm-match-plugin nil t)
+(require 'helm-multi-match nil t)
 (require 'helm-elisp)
 (require 'auto-complete)
 (require 'cl-lib)


### PR DESCRIPTION
helm-match-plugin.el is renamed at the following commit
https://github.com/emacs-helm/helm/commit/b26db373b005f237efde253616c4db585eca1fd1
